### PR TITLE
Make 'SerialPortNameToUse' property read/writable

### DIFF
--- a/client/XdkHeadTrack/View/Model/MainViewModel.cs
+++ b/client/XdkHeadTrack/View/Model/MainViewModel.cs
@@ -41,7 +41,7 @@ namespace XdkHeadTrack.View.Model
 		public string SerialPortNameToUse
 		{
 			get { return _serialPortNameToUse; }
-			private set { _serialPortNameToUse = value; NotifyPropertyChanged(); }
+			set { _serialPortNameToUse = value; NotifyPropertyChanged(); }
 		}
 
 		public bool IsUdpSenderActive


### PR DESCRIPTION
This fixes an issue when running the app standalone (outside Visual
Studio environment), where it failed to start in some environments.